### PR TITLE
Mundando endereços de endpoit conforme notificação da Zenvia

### DIFF
--- a/src/HumanSms/Client.php
+++ b/src/HumanSms/Client.php
@@ -4,7 +4,7 @@ namespace HumanSms;
 
 class Client
 {
-    const URL_SINGLE_SMS = 'http://system.human.com.br/GatewayIntegration/msgSms.do';
+    const URL_SINGLE_SMS = 'https://api-http.zenvia.com/GatewayIntegration/msgSms.do';
 
     protected $account;
     protected $code;


### PR DESCRIPTION
Alteração de acordo com a notificação da Zenvia.

---
Prezado cliente,

Já realizou a mudança de URLs das APIs da Zenvia? 
Nosso objetivo é melhorar as nossas políticas de segurança, que são baseadas nas melhores práticas de mercado. 

Não deixe para a última hora, já estamos há menos de um mês da descontinuidade das URLs antigas. 

API | ENDPOINT ATUAL | NOVO ENDPOINT
-- | -- | --
HTTP | HTTP ou HTTPS://200.203.125.26/GatewayIntegrationHTTP ou HTTPS://200.203.125.27/GatewayIntegrationHTTP ou HTTPS://200.203.125.27:8080/GatewayIntegrationHTTP ou HTTPS://api-connect.zenvia360.com/GatewayIntegrationHTTP ou HTTPS://system.human.com.br/GatewayIntegrationHTTP ou HTTPS://system.human.com.br:8080/GatewayIntegrationHTTP ou HTTPS://www.zenvia360.com.br/GatewayIntegrationHTTP ou HTTPS://zenvia360.com.br/GatewayIntegration | https://api-http.zenvia.com/GatewayIntegration
REST | HTTP ou HTTPS://api-rest.zenvia360.com.br/servicesHTTPS://api-rest.zenvia360.com.br:443/servicesHTTP ou HTTPS://api-rest2.zenvia360.com.br/services | https://api-rest.zenvia.com/services
SOAP | HTTP ou HTTPS://api-soap.zenvia360.com.br/servicesHTTP ou HTTPS://api.zenvia360.com.br/services | https://api-soap.zenvia.com/services

As novas URLs estão disponíveis somente através do protocolo HTTPS e já possuem o certificado atualizado. As antigas serão descontinuadas no dia **18 de agosto de 2018**.

Salientamos: para estar em conformidade com as melhores práticas de segurança da informação, desativamos os ciphers e algoritmos de criptografía (SSLv3, RC4, etc) devido às vulnerabilidades Poodle (SSLv3), BEAST, entre outras. Isto significa que os novos endpoints aceitam apenas conexões seguras usando o protocolo TLS v1.2. 

Caso a implementação da sua integração com estas APIs use pinning de certificado SSL, será necessário realizar o [download do novo arquivo por meio deste link](http://zenlink.zenvia.com/cl/PDmdh/HN/bb7e/L_BMlc89566/BKHr/FfNGXS9w4q1/1/).
 
IMPORTANTE:
Não esqueça de revisar as políticas de segurança de sua empresa, pois essas devem estar liberadas para a comunicação com os seguintes endereçamentos IP da Zenvia:

IPv4
- 201.150.94.192/27
- 200.203.125.24/29
- 200.203.125.64/28
- 45.233.20.0/22

IPv6
- 2804:4b80::/32 

A substituição destas URL's é um procedimento simples e não deverá causar qualquer tipo de impacto em sua operação. Mas caso necessário, estamos a sua disposição pelo e-mail atendimento@zenvia.com.

Abraço,
Equipe Zenvia